### PR TITLE
Use monitoring module for actuator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.activiti.cloud</groupId>
-  <version>7-201711-EA-ryan_1552_auth_conf_from_props-SNAPSHOT</version>
+  <version>7-201711-EA-SNAPSHOT</version>
   <artifactId>activiti-cloud-gateway</artifactId>
 
   <name>Activiti Cloud :: Gateway</name>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,10 @@
       <artifactId>activiti-cloud-services-identity-keycloak</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-services-monitoring</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.activiti.cloud</groupId>
-  <version>7-201711-EA-SNAPSHOT</version>
+  <version>7-201711-EA-ryan_1552_auth_conf_from_props-SNAPSHOT</version>
   <artifactId>activiti-cloud-gateway</artifactId>
 
   <name>Activiti Cloud :: Gateway</name>


### PR DESCRIPTION
Created a monitoring module to enclose spring-boot-starter-actuator as it's anticipated we'll want more monitoring in future. Want actuator for liveness probes. Change under https://github.com/Activiti/Activiti/issues/1552